### PR TITLE
Fix search bug to account for different songs that have identical names

### DIFF
--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -27,9 +27,9 @@ function Search({showSearch, playSong, setError}) {
                 results.length > 0 &&
                 <div className={"overflow-x-auto results"}>
                     {
-                        results.map(song =>
+                        results.map((song, index) =>
                             <Song
-                                key={song.name}
+                                key={index}
                                 name={song.name}
                                 length={song.length}
                                 playSong={playSong}


### PR DESCRIPTION
Recap:
- There are two songs named "Sorry" in the mock data.
- So the search component returns incorrect results because it's using `song.name` as the key.
- Mike advised against using `song.id` to fix this because according to the [API documentation](https://github.com/iO-Academy/music-player-api-template), `song.id` is not part of the JSON objects that get returned.

I tried using `artwork_url` as the key: although this avoids the "Sorry" problem where more and more songs named "Sorry" appear in the search results, the results are still wrong (e.g. searching "Sorry" doesn't return two and only two songs named "Sorry").

[Adam](https://github.com/youngy247) found the fix you see in the code here and deployed it using this fix.

You can [find the demo here](https://23-mar-icantbelieveitsnotspotify.netlify.app/) to try it out. 